### PR TITLE
[InstallBundle] Change secret to 32 bits instead of 64, to avoid algo…

### DIFF
--- a/src/CSBill/InstallBundle/Command/InstallCommand.php
+++ b/src/CSBill/InstallBundle/Command/InstallCommand.php
@@ -202,7 +202,7 @@ class InstallCommand extends ContainerAwareCommand
             'mailer_encryption' => $input->getOption('mailer-encryption'),
             'locale' => $input->getOption('locale'),
             'currency' => $input->getOption('currency'),
-            'secret' => $factory->getMediumStrengthGenerator()->generateString(64),
+            'secret' => $factory->getMediumStrengthGenerator()->generateString(32),
         );
 
         $this->getContainer()->get('csbill.core.config_writer')->dump($config);

--- a/src/CSBill/InstallBundle/Process/Step/SetupStep.php
+++ b/src/CSBill/InstallBundle/Process/Step/SetupStep.php
@@ -132,7 +132,7 @@ class SetupStep extends ControllerStep
             'locale' => $data['locale'],
             'currency' => $data['currency'],
             'installed' => $time->format(\DateTime::ISO8601),
-            'secret' => $factory->getMediumStrengthGenerator()->generateString(64)
+            'secret' => $factory->getMediumStrengthGenerator()->generateString(32)
         );
 
         $this->get('csbill.core.config_writer')->dump($config);


### PR DESCRIPTION
…rithm key size error

Using a key size bigger than 32 gives the following error:

Warning: mcrypt_encrypt(): Key of size 64 not supported by this algorithm. Only keys of sizes 16, 24 or 32 supported 