### PR TITLE
Fix error when trying to create a payment

### DIFF
--- a/src/CSBill/PaymentBundle/Action/PaypalExpress/CapturePaymentAction.php
+++ b/src/CSBill/PaymentBundle/Action/PaypalExpress/CapturePaymentAction.php
@@ -81,7 +81,7 @@ class CapturePaymentAction extends GatewayAwareAction
         }
 
         /*$notifyUrl = $this->tokenFactory->createNotifyToken(
-            $request->getToken()->getPaymentName(),
+            $request->getToken()->getGatewayName(),
             $payment
         )->getTargetUrl();
 

--- a/src/CSBill/PaymentBundle/Controller/PaymentController.php
+++ b/src/CSBill/PaymentBundle/Controller/PaymentController.php
@@ -21,6 +21,7 @@ use CSBill\PaymentBundle\Event\PaymentCompleteEvent;
 use CSBill\PaymentBundle\Event\PaymentEvents;
 use CSBill\PaymentBundle\Form\PaymentForm;
 use CSBill\PaymentBundle\Model\Status;
+use Payum\Core\Model\Token;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -148,9 +149,10 @@ class PaymentController extends BaseController
      */
     public function captureDoneAction(Request $request)
     {
+        /** @var Token $token */
         $token = $this->get('payum.security.http_request_verifier')->verify($request);
 
-        $paymentMethod = $this->get('payum')->getGateway($token->getPaymentName());
+        $paymentMethod = $this->get('payum')->getGateway($token->getGatewayName());
         $paymentMethod->execute($status = new StatusRequest($token));
 
         /** @var \CSBill\PaymentBundle\Entity\Payment $payment */


### PR DESCRIPTION
The method `getPaymentName` has changes to `getGateway` name, so this gives an error when trying to create a payment