### PR TITLE
Set invoice balance when converting a quote to an invoice

### DIFF
--- a/src/CSBill/InvoiceBundle/Manager/InvoiceManager.php
+++ b/src/CSBill/InvoiceBundle/Manager/InvoiceManager.php
@@ -89,6 +89,7 @@ class InvoiceManager extends ContainerAware
         $invoice->setTotal($quote->getTotal());
         $invoice->setTerms($quote->getTerms());
         $invoice->setUsers($quote->getUsers()->toArray());
+        $invoice->setBalance($invoice->getTotal());
 
         if (null !== $quote->getTax()) {
             $invoice->setTax($quote->getTax());


### PR DESCRIPTION
The `balance` column cannot be empty, which gives an error when trying to convert a quote to an invoice