### PR TITLE
Fix client grid credit column

### DIFF
--- a/src/CSBill/ClientBundle/Entity/Client.php
+++ b/src/CSBill/ClientBundle/Entity/Client.php
@@ -117,7 +117,7 @@ class Client
      * @var Credit
      *
      * @ORM\OneToOne(targetEntity="CSBill\ClientBundle\Entity\Credit", mappedBy="client", fetch="EXTRA_LAZY", cascade={"persist", "remove"})
-     * @GRID\Column(field="credit.value", title="Credit", type="number", style="currency")
+     * @GRID\Column(field="credit.value", title="Credit", type="currency")
      */
     private $credit;
 


### PR DESCRIPTION
The number column in the grid currently has issues when specifying it as a currency type, because it needs locales with a language and a country code (E.G en_US) and breaks with locales with only a language (E.G af). So use the dedicated currency column instead