### PR TITLE
Fix additional details display on contact card

### DIFF
--- a/src/CSBill/ClientBundle/Resources/public/templates/contact.hbs
+++ b/src/CSBill/ClientBundle/Resources/public/templates/contact.hbs
@@ -9,11 +9,11 @@
             <dd>{{ email }}</dd>
         </dl>
 
-        {{#if additionalDetails}}
+        {{#if additional_details}}
             <h5>{{trans 'client.contact.details.extra'}}</h5>
             <dl class="dl-horizontal">
                 {{#each additional_details }}
-                    <dt>{{ this.type }}:</dt>
+                    <dt>{{title this.type }}:</dt>
                     <dd>{{ this.value }}</dd>
                 {{/each}}
             </dl>


### PR DESCRIPTION
Fix variable name in contact card template to correctly display additional details