### PR TITLE
Use constant when displaying application name

### DIFF
--- a/src/CoreBundle/Resources/views/Layout/default.html.twig
+++ b/src/CoreBundle/Resources/views/Layout/default.html.twig
@@ -57,7 +57,7 @@
 {% endblock header %}
 
 {% block footer %}
-    <small>{{ "powered_by"|trans }} <a href="http://csbill.org">CSBill</a> - {{ app_version }}</small>
+    <small>{{ "powered_by"|trans }} <a href="http://csbill.org">{{ constant('CSBill\\CoreBundle\\CSBillCoreBundle::APP_NAME') }}</a> - {{ app_version }}</small>
 {% endblock footer %}
 
 {% block body_bottom %}

--- a/src/InstallBundle/Resources/views/layout.html.twig
+++ b/src/InstallBundle/Resources/views/layout.html.twig
@@ -12,7 +12,7 @@
 {% from "@CSBillInstall/Macro/install_progress.html.twig" import progress %}
 
 {% block title %}
-    {{ "installation.title"|trans({"%app_name%" : 'CSBill'}) ~ ' - ' ~ ('installation.progress.step.' ~ context.currentStep.name)|trans }}
+    {{ "installation.title"|trans({"%app_name%" : constant('CSBill\\CoreBundle\\CSBillCoreBundle::APP_NAME')}) ~ ' - ' ~ ('installation.progress.step.' ~ context.currentStep.name)|trans }}
 {% endblock title %}
 
 {% block content %}


### PR DESCRIPTION
Use the defined constant when displaying the application name instead of hard-coding it